### PR TITLE
Added missing import for getTPLReadLoc

### DIFF
--- a/src/org/rascalmpl/core/library/lang/rascalcore/check/Summary.rsc
+++ b/src/org/rascalmpl/core/library/lang/rascalcore/check/Summary.rsc
@@ -7,6 +7,8 @@ extend lang::rascalcore::check::CheckerCommon;
 //
 //extend analysis::typepal::TypePal;
 
+import lang::rascalcore::check::Import;
+
 import util::Reflective;
 
 import IO;


### PR DESCRIPTION
There's a missing import for the call to `getTPLReadLoc` on line 79, breaking use/def and hovering in VSCode. This import fixes this, but I cannot oversee any consequences it may have, @PaulKlint 