### PR TITLE
Improving speed over overal type-checking by factor 2

### DIFF
--- a/src/org/rascalmpl/core/library/lang/rascalcore/check/RascalConfig.rsc
+++ b/src/org/rascalmpl/core/library/lang/rascalcore/check/RascalConfig.rsc
@@ -354,7 +354,7 @@ void checkOverloading(map[str,Tree] namedTrees, Solver s){
     try {
     consDef = range(consNameDef);
     consTypes = (d : s.getType(d) | d <- consDef);
-    for(d1 <- consDef, d2 <- consDef, d1.defined != d2.defined, t1 := consTypes[d1], t2 := consTypes[d1], t1.adt == t2.adt,
+    for(d1 <- consDef, d2 <- consDef, d1.defined != d2.defined, t1 := consTypes[d1], t2 := consTypes[d2], t1.adt == t2.adt,
         d1.scope in moduleScopes && d2.scope in moduleScopes){
         for(fld1 <- t1.fields, fld2 <- t2.fields, fld1.label == fld2.label, !isEmpty(fld1.label), !comparable(fld1, fld2)){
             msgs = [ warning("Field `<fld1.label>` is declared with different types in constructors `<d1.id>` and `<d2.id>` for `<t1.adt.adtName>`", d1.defined)

--- a/src/org/rascalmpl/core/library/lang/rascalcore/check/RascalConfig.rsc
+++ b/src/org/rascalmpl/core/library/lang/rascalcore/check/RascalConfig.rsc
@@ -353,7 +353,8 @@ void checkOverloading(map[str,Tree] namedTrees, Solver s){
     }
     try {
     consDef = range(consNameDef);
-    for(d1 <- consDef, d2 <- consDef, d1.defined != d2.defined, t1 := s.getType(d1), t2 := s.getType(d2), t1.adt == t2.adt,
+    consTypes = (d : s.getType(d) | d <- consDef);
+    for(d1 <- consDef, d2 <- consDef, d1.defined != d2.defined, t1 := consTypes[d1], t2 := consTypes[d1], t1.adt == t2.adt,
         d1.scope in moduleScopes && d2.scope in moduleScopes){
         for(fld1 <- t1.fields, fld2 <- t2.fields, fld1.label == fld2.label, !isEmpty(fld1.label), !comparable(fld1, fld2)){
             msgs = [ warning("Field `<fld1.label>` is declared with different types in constructors `<d1.id>` and `<d2.id>` for `<t1.adt.adtName>`", d1.defined)

--- a/src/org/rascalmpl/core/library/lang/rascalcore/check/RascalConfig.rsc
+++ b/src/org/rascalmpl/core/library/lang/rascalcore/check/RascalConfig.rsc
@@ -352,10 +352,8 @@ void checkOverloading(map[str,Tree] namedTrees, Solver s){
         }      
     }
     try {
-    consDef = range(consNameDef);
-    consTypes = (d : s.getType(d) | d <- consDef);
-    for(d1 <- consDef, d2 <- consDef, d1.defined != d2.defined, t1 := consTypes[d1], t2 := consTypes[d2], t1.adt == t2.adt,
-        d1.scope in moduleScopes && d2.scope in moduleScopes){
+    matchingConds = [ <d, t, t.adt> | <_, Define d> <- consNameDef, d.scope in moduleScopes, t := s.getType(d)];
+    for(<Define d1, AType t1, same_adt> <- matchingConds, <Define d2, AType t2, same_adt> <- matchingConds, d1.defined != d2.defined){
         for(fld1 <- t1.fields, fld2 <- t2.fields, fld1.label == fld2.label, !isEmpty(fld1.label), !comparable(fld1, fld2)){
             msgs = [ warning("Field `<fld1.label>` is declared with different types in constructors `<d1.id>` and `<d2.id>` for `<t1.adt.adtName>`", d1.defined)
                    ];


### PR DESCRIPTION
I tested this, and it reduced the runtime for typechecking the parsergenerator from 800s to 350s.

I think there might be some more performance gains to make by using a smarter datastructure to detect common types (a rel comes to mind) but I leave that for you to think about.