### PR TITLE
Make publishing test results work for fork pull requests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Build and Deploy 
+name: Build and Deploy
 on:
   push:
     branches:
@@ -34,12 +34,13 @@ jobs:
       - name: Compile, Generate and Test (never fails)
         run: mvn -B -Dmaven.test.failure.ignore -Drascal.test.memory=4  test
 
-      - name: Publish Test Report
-        uses: EnricoMi/publish-unit-test-result-action/composite@v1
-        if: ${{ always() && github.event_name != 'pull_request' }} # to bad this doesn't work nicely with external pull requests
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
         with:
-          files: target/surefire-reports/**/*.xml
-          check_run_annotations: 'all tests, skipped tests'
+          name: Test Results
+          path: |
+            target/surefire-reports/**/*.xml
 
       - name: Attach artifact
         id: build-artifact
@@ -68,3 +69,13 @@ jobs:
           ssh-username: ${{ secrets.RELEASE_SSH_USERNAME }}
           ssh-private-key: ${{ secrets.RELEASE_SSH_PRIVATE_KEY }}
           maven-options: "-Drascal.generate.skip"
+
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: Event File
+          path: ${{ github.event_path }}

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,0 +1,40 @@
+name: Publish Test Report
+
+on:
+  workflow_run:
+    workflows: ["Build and Deploy"]
+    types:
+      - completed
+
+jobs:
+  test-results:
+    name: Publish Test Report
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          mkdir -p artifacts && cd artifacts
+
+          artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+          gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+          do
+            IFS=$'\t' read name url <<< "$artifact"
+            gh api $url > "$name.zip"
+            unzip -d "$name" "$name.zip"
+          done
+
+      - name: Publish Test Report
+        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          check_name: Test Results
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: 'artifacts/**/*.xml'
+          check_run_annotations: 'all tests, skipped tests'
+


### PR DESCRIPTION
This should allow to report test results for fork PRs. For more details and example code, see https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches.

Sadly, can only be tested once merged to master.