### PR TITLE
Replace colon in result file names as upload action does not like

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,6 +34,17 @@ jobs:
       - name: Compile, Generate and Test (never fails)
         run: mvn -B -Dmaven.test.failure.ignore -Drascal.test.memory=4  test
 
+      - name: Rename colon in file names
+        run: |
+          find target/surefire-reports -name '*.xml' | while read file
+          do
+            if [[ "$file" == *:* ]]
+            then
+              # replace the colon with a unicode character that looks similar
+              mv -v "$file" "${file//:/꞉}"
+            fi
+          done
+
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -35,6 +35,6 @@ jobs:
           check_name: Test Results
           event_file: artifacts/Event File/event.json
           event_name: ${{ github.event.workflow_run.event }}
-          files: 'artifacts/**/*.xml'
+          files: 'artifacts/Test Results/**/*.xml'
           check_run_annotations: 'all tests, skipped tests'
 


### PR DESCRIPTION
Unfortunately, the upload action does not like test files that contain colons (`:`).

This replaces those colon characters with similar unicode characters.