### PR TITLE
removal of test modules scheme usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
         <dependency>
         	<groupId>org.rascalmpl</groupId>
         	<artifactId>rascal</artifactId>
-        	<version>0.30.1</version>
+        	<version>0.34.0-RC1</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/org/rascalmpl/core/library/lang/rascalcore/check/AllRascalTests.rsc
+++ b/src/org/rascalmpl/core/library/lang/rascalcore/check/AllRascalTests.rsc
@@ -421,7 +421,7 @@ void allFiles(PathConfig pcfg = pathConfig(
                 |project://salix/src|
                 //|std:///|
                ],
-         bin = |test-modules:///rascal-core-bin|,
+         bin = |memory://test-modules/rascal-core-bin|,
          libs = [/*|lib://rascal/|, |lib://typepal/|*/])){
     modulePaths =  find(|project://rascal/src/org/rascalmpl/library|, bool(loc l) { return endsWith(l.path, ".rsc"); });
                    //find(|std:///lang/rascal/tests|, bool(loc l) { return endsWith(l.path, ".rsc"); });

--- a/src/org/rascalmpl/core/library/lang/rascalcore/check/Checker.rsc
+++ b/src/org/rascalmpl/core/library/lang/rascalcore/check/Checker.rsc
@@ -137,9 +137,9 @@ void rascalPreCollectInitialization(map[str, Tree] namedTrees, Collector c){
 
 private int npc = 0;
 @doc{
-  PathConfig for testing generated modules in |test-modules:///| in memory file system.
+  PathConfig for testing generated modules in |memory://test-modules/| in memory file system.
   
-  * gets source files exclusively from |test-modules:///|
+  * gets source files exclusively from |memory://test-modules/|
   * generates bin files in the in-memory file system 
   * depends only on the pre-compiled standard library from the rascal project 
 }
@@ -147,8 +147,8 @@ public PathConfig getDefaultPathConfig() {
     npc += 1;
     snpc = "<npc>";
     return pathConfig(   
-        srcs = [|test-modules:///| /* test-modules is an in-memory file-system */], 
-        bin = |test-modules:///rascal-core-tests-bin-<snpc>|, 
+        srcs = [|memory://test-modules/| /* test-modules is an in-memory file-system */], 
+        bin = |memory://test-modules/rascal-core-tests-bin-<snpc>|, 
         libs = [|lib://rascal/|]
     );
 }
@@ -186,7 +186,7 @@ public PathConfig getRascalProjectPathConfig() {
     snpc = "<npc>";
     return pathConfig(   
         srcs = [|project://rascal/src/org/rascalmpl/library|], 
-        bin = |test-modules:///rascal-lib-bin-<snpc>|, 
+        bin = |memory://test-modules/rascal-lib-bin-<snpc>|, 
         libs = []
     );  
 }  

--- a/src/org/rascalmpl/core/library/lang/rascalcore/check/tests/StaticTestingUtils.rsc
+++ b/src/org/rascalmpl/core/library/lang/rascalcore/check/tests/StaticTestingUtils.rsc
@@ -44,7 +44,7 @@ loc buildModule(str stmts,  list[str] importedModules = [], list[str] initialDec
 }
 
 loc makeModule(str name, str body){
-    mloc = |test-modules:///<name>.rsc|;
+    mloc = |memory://test-modules/<name>.rsc|;
     writeFile(mloc, "@bootstrapParser
                      'module <name>
                      '<body>");

--- a/src/org/rascalmpl/core/library/lang/rascalcore/compile/Compile.rsc
+++ b/src/org/rascalmpl/core/library/lang/rascalcore/compile/Compile.rsc
@@ -116,12 +116,12 @@ list[Message] compile(str qualifiedModuleName, PathConfig pcfg, loc reloc=|norel
 //list[RVMModule] compile(list[str] qualifiedModuleNames, PathConfig pcfg, loc reloc=|noreloc:///|, bool verbose = false, bool optimize=true, bool enableAsserts=false){
 //    uniq = uuidi();
 //    containerName = "Container<uniq < 0 ? -uniq : uniq>";
-//    containerLocation = |test-modules:///<containerName>.rsc|;
+//    containerLocation = |memory://test-modules/<containerName>.rsc|;
 //    container = "module <containerName>
 //                '<for(str m <- qualifiedModuleNames){>
 //                'import <escapeQualifiedName(m)>;<}>";
 //    writeFile(containerLocation, container);
-//    pcfg.srcs = |test-modules:///| + pcfg.srcs;
+//    pcfg.srcs = |memory://test-modules/| + pcfg.srcs;
 //    
 //    rvmContainer = compile(containerName, pcfg, reloc=reloc, verbose=verbose, optimize=optimize, enableAsserts=enableAsserts);
 //    set[Message] messages = {};

--- a/src/org/rascalmpl/core/library/lang/rascalcore/compile/Execute.rsc
+++ b/src/org/rascalmpl/core/library/lang/rascalcore/compile/Execute.rsc
@@ -552,7 +552,7 @@ RVMProgram compileAndMergeProgramIncremental(str qualifiedModuleName, bool reuse
             bool jvm=true, 
             bool verbose=false, 
             bool optimize=true){
-   //pcfg = pathConfig(srcs=[|std:///|, |test-modules:///|], bin=|home:///bin-console|, libs=[|home:///bin-console|]);
+   //pcfg = pathConfig(srcs=[|std:///|, |memory://test-modules|], bin=|home:///bin-console|, libs=[|home:///bin-console|]);
    //pcfg = pathConfig(srcs=srcs, libs=libs, boot=boot, bin=bin);
    if(!reuseConfig){
       mergedImportLoc = getMergedImportsWriteLoc(qualifiedModuleName, pcfg);

--- a/src/org/rascalmpl/core/library/lang/rascalcore/compile/runtime/$RascalModule.java
+++ b/src/org/rascalmpl/core/library/lang/rascalcore/compile/runtime/$RascalModule.java
@@ -207,7 +207,6 @@ public abstract class $RascalModule /*extends ATypeFactory*/ {
 						@Override
 						public Set<ISourceLocation> findResources(String fileName) {
 							Set<ISourceLocation> result = new HashSet<>();
-							URIResolverRegistry reg = URIResolverRegistry.getInstance();
 
 							try {
 								for (URL found : Collections.list(getClass().getClassLoader().getResources(fileName))) {

--- a/src/org/rascalmpl/core/library/lang/rascalcore/compile/runtime/utils/ExecutionTools.java
+++ b/src/org/rascalmpl/core/library/lang/rascalcore/compile/runtime/utils/ExecutionTools.java
@@ -46,10 +46,10 @@ public class ExecutionTools<T> {
 		} catch (JavaCompilerException e) {
 			if (!e.getDiagnostics().getDiagnostics().isEmpty()) {
 		        Diagnostic<? extends JavaFileObject> msg = e.getDiagnostics().getDiagnostics().iterator().next();
-		        throw new JavaCompilation(msg.getMessage(null) + " at " + msg.getLineNumber() + ", " + msg.getColumnNumber(), e);
+		        throw new JavaCompilation(msg.getMessage(null), msg.getLineNumber(),  msg.getColumnNumber(), classModule, javaCompiler.getClassLoader().toString(), e);
 		    }
 		    else {
-		        throw new JavaCompilation(e.getMessage(), e);
+				throw new JavaCompilation(e.getMessage(), 1, 0, classModule, javaCompiler.getClassLoader().toString(), e);
 		    }
 		}
 	}

--- a/src/org/rascalmpl/core/library/lang/rascalcore/compile/runtime/utils/JavaBridge.java
+++ b/src/org/rascalmpl/core/library/lang/rascalcore/compile/runtime/utils/JavaBridge.java
@@ -59,15 +59,15 @@ public class JavaBridge {
             return result;
         } 
         catch (ClassCastException e) {
-            throw new JavaCompilation(e.getMessage(), e);
+            throw new JavaCompilation(e.getMessage(), 1, 0, source, javaCompilerPath, e);
         } 
         catch (JavaCompilerException e) {
             if (!e.getDiagnostics().getDiagnostics().isEmpty()) {
                 Diagnostic<? extends JavaFileObject> msg = e.getDiagnostics().getDiagnostics().iterator().next();
-                throw new JavaCompilation(msg.getMessage(null) + " at " + msg.getLineNumber() + ", " + msg.getColumnNumber() + " with classpath [" + javaCompilerPath + "]", e);
+                throw new JavaCompilation(msg.getMessage(null), msg.getLineNumber(), msg.getColumnNumber(), source, javaCompilerPath, e);
             }
             else {
-                throw new JavaCompilation(e.getMessage(), e);
+                throw new JavaCompilation(e.getMessage(), 1, 0, source, javaCompilerPath, e);
             }
         }
     }


### PR DESCRIPTION
- Replaced usage of `|test-modules:///|` by `memory://test-modules/`
- updated JavaCompilerError exceptions to new API (for better tracing of error locations into Rascal)
- bumped to latest rascal, including the memory:/// file scheme that can replace test-modules:///
